### PR TITLE
feat: persist query client to disk

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
   "dependencies": {
     "@inkjs/ui": "^2.0.0",
     "@tanstack/react-query": "^5.66.0",
+    "@tanstack/react-query-persist-client": "^5.69.0",
     "chalk": "5.4.1",
     "date-fns": "^4.1.0",
     "fullscreen-ink": "^0.0.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,6 +14,9 @@ importers:
       '@tanstack/react-query':
         specifier: ^5.66.0
         version: 5.66.0(react@18.3.1)
+      '@tanstack/react-query-persist-client':
+        specifier: ^5.69.0
+        version: 5.69.0(@tanstack/react-query@5.66.0(react@18.3.1))(react@18.3.1)
       chalk:
         specifier: 5.4.1
         version: 5.4.1
@@ -131,6 +134,18 @@ packages:
 
   '@tanstack/query-core@5.66.0':
     resolution: {integrity: sha512-J+JeBtthiKxrpzUu7rfIPDzhscXF2p5zE/hVdrqkACBP8Yu0M96mwJ5m/8cPPYQE9aRNvXztXHlNwIh4FEeMZw==}
+
+  '@tanstack/query-core@5.69.0':
+    resolution: {integrity: sha512-Kn410jq6vs1P8Nm+ZsRj9H+U3C0kjuEkYLxbiCyn3MDEiYor1j2DGVULqAz62SLZtUZ/e9Xt6xMXiJ3NJ65WyQ==}
+
+  '@tanstack/query-persist-client-core@5.69.0':
+    resolution: {integrity: sha512-OisxDgcDH0ajswGBA+TXXSn5uzll1EaCB6/MQH+2+t4JqR/qq5TS8nh6A7pas/GBFB01kNpgKRYmZp0tkKVtOg==}
+
+  '@tanstack/react-query-persist-client@5.69.0':
+    resolution: {integrity: sha512-/uIblBRwnpms6Xu+71Jy+2V+iuWrSyDfeYVNp8kbyYOKP9135ii/S80+EXBGeM/jx7+vizRGORaq4kKuKXo6Sw==}
+    peerDependencies:
+      '@tanstack/react-query': ^5.69.0
+      react: ^18 || ^19
 
   '@tanstack/react-query@5.66.0':
     resolution: {integrity: sha512-z3sYixFQJe8hndFnXgWu7C79ctL+pI0KAelYyW+khaNJ1m22lWrhJU2QrsTcRKMuVPtoZvfBYrTStIdKo+x0Xw==}
@@ -546,6 +561,18 @@ snapshots:
       ink: 5.1.0(@types/react@18.3.18)(react@18.3.1)
 
   '@tanstack/query-core@5.66.0': {}
+
+  '@tanstack/query-core@5.69.0': {}
+
+  '@tanstack/query-persist-client-core@5.69.0':
+    dependencies:
+      '@tanstack/query-core': 5.69.0
+
+  '@tanstack/react-query-persist-client@5.69.0(@tanstack/react-query@5.66.0(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@tanstack/query-persist-client-core': 5.69.0
+      '@tanstack/react-query': 5.66.0(react@18.3.1)
+      react: 18.3.1
 
   '@tanstack/react-query@5.66.0(react@18.3.1)':
     dependencies:

--- a/src/api/get-issue-transitions.query.ts
+++ b/src/api/get-issue-transitions.query.ts
@@ -26,7 +26,6 @@ export const useGetIssueTransitionsQuery = (
   return useQuery({
     queryKey: ["priorities", issueId],
     queryFn: () => fetchIssueTransitions(issueId),
-    gcTime: HOUR,
     staleTime: HOUR,
     enabled,
   });

--- a/src/api/get-priorities.query.ts
+++ b/src/api/get-priorities.query.ts
@@ -21,7 +21,6 @@ export const useGetPrioritiesQuery = (projectId: string, enabled = true) => {
   return useQuery({
     queryKey: ["priorities"],
     queryFn: () => fetchPriorities(projectId),
-    gcTime: HOUR,
     staleTime: HOUR,
     enabled,
   });

--- a/src/api/get-users.query.ts
+++ b/src/api/get-users.query.ts
@@ -19,7 +19,6 @@ export const useGetUsersQuery = (issueId: string | number) => {
   return useQuery({
     queryKey: ["users"],
     queryFn: () => fetchUsers(issueId),
-    gcTime: HOUR,
     staleTime: HOUR,
   });
 };

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -9,7 +9,7 @@ import { createFilePersister } from "./lib/query-storage-persister.js";
 const queryClient = new QueryClient({
   defaultOptions: {
     queries: {
-      gcTime: 1000 * 60 * 60 * 24, // 24 hours
+      gcTime: 1000 * 60 * 60 * 24 * 7, // 1 week
     },
   },
 });

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -1,15 +1,28 @@
-import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { QueryClient } from "@tanstack/react-query";
+import { PersistQueryClientProvider } from "@tanstack/react-query-persist-client";
 import { Box, Text } from "ink";
 import { Provider } from "jotai";
 import { store } from "./atoms/store.js";
 import { BoardView } from "./board-view.js";
+import { createFilePersister } from "./lib/query-storage-persister.js";
 
-const queryClient = new QueryClient();
+const queryClient = new QueryClient({
+  defaultOptions: {
+    queries: {
+      gcTime: 1000 * 60 * 60 * 24, // 24 hours
+    },
+  },
+});
+
+const persister = createFilePersister();
 
 export const App = () => {
   return (
     <Provider store={store}>
-      <QueryClientProvider client={queryClient}>
+      <PersistQueryClientProvider
+        client={queryClient}
+        persistOptions={{ persister }}
+      >
         <Box flexDirection="column" width={"100%"} height={"100%"}>
           <Text> JIRA TIME</Text>
           <Box
@@ -21,7 +34,7 @@ export const App = () => {
             <BoardView />
           </Box>
         </Box>
-      </QueryClientProvider>
+      </PersistQueryClientProvider>
     </Provider>
   );
 };

--- a/src/lib/log.ts
+++ b/src/lib/log.ts
@@ -10,3 +10,11 @@ export const log = (text: string) => {
     }
   });
 };
+
+export const makeLogger = (prefix: string) => {
+  return {
+    log: (text: string) => {
+      log(`[${prefix}]: ${text}`);
+    },
+  };
+};

--- a/src/lib/query-storage-persister.ts
+++ b/src/lib/query-storage-persister.ts
@@ -1,0 +1,62 @@
+import { existsSync, mkdirSync } from "node:fs";
+import { readFile, unlink, writeFile } from "node:fs/promises";
+import { homedir } from "node:os";
+import path from "node:path";
+import type {
+  PersistedClient,
+  Persister,
+} from "@tanstack/react-query-persist-client";
+import { makeLogger } from "./log.js";
+import { throttleWithTrailing } from "./utils/throttle-with-trailing.js";
+
+const CACHE_LOCATION = path.join(
+  homedir(),
+  ".cache",
+  "jira-tui",
+  "query-client.json",
+);
+
+// Ensure the cache directory exists
+const cacheDir = path.dirname(CACHE_LOCATION);
+if (!existsSync(cacheDir)) {
+  mkdirSync(cacheDir, { recursive: true });
+}
+
+const logger = makeLogger("QueryStoragePersister");
+
+// Throttle the persisting of the client to avoid spamming the disk
+const THROTTLING_TIME = 5000;
+
+export function createFilePersister() {
+  return {
+    persistClient: throttleWithTrailing(async (client: PersistedClient) => {
+      try {
+        logger.log("Persisting client");
+        await writeFile(CACHE_LOCATION, JSON.stringify(client));
+      } catch (error) {
+        logger.log(
+          `Could not persist client: ${error instanceof Error ? error.message : error}`,
+        );
+      }
+    }, THROTTLING_TIME),
+    restoreClient: async () => {
+      logger.log("Restoring client");
+      try {
+        return JSON.parse(await readFile(CACHE_LOCATION, "utf-8"));
+      } catch (error) {
+        logger.log(
+          `Could not restore client: ${error instanceof Error ? error.message : error}`,
+        );
+      }
+    },
+    removeClient: async () => {
+      try {
+        await unlink(CACHE_LOCATION);
+      } catch (error) {
+        logger.log(
+          `Could not remove client: ${error instanceof Error ? error.message : error}`,
+        );
+      }
+    },
+  } satisfies Persister;
+}

--- a/src/lib/utils/throttle-with-trailing.ts
+++ b/src/lib/utils/throttle-with-trailing.ts
@@ -1,0 +1,38 @@
+export function throttleWithTrailing<
+  // biome-ignore lint/suspicious/noExplicitAny: required for generic function
+  T extends (...args: any[]) => unknown | Promise<unknown>,
+>(func: T, wait: number): T {
+  let timeout: ReturnType<typeof setTimeout> | null = null;
+  let lastArgs: Parameters<T> | null = null;
+  let lastThis: ThisParameterType<T> | null = null;
+  let lastCallTime = 0;
+
+  const invoke = () => {
+    if (lastArgs) {
+      func.apply(lastThis, lastArgs);
+      lastArgs = lastThis = null;
+      lastCallTime = Date.now();
+    }
+  };
+
+  return function (this: ThisParameterType<T>, ...args: Parameters<T>) {
+    const now = Date.now();
+    const remaining = wait - (now - lastCallTime);
+
+    lastArgs = args;
+    lastThis = this;
+
+    if (remaining <= 0) {
+      if (timeout) {
+        clearTimeout(timeout);
+        timeout = null;
+      }
+      invoke();
+    } else if (!timeout) {
+      timeout = setTimeout(() => {
+        timeout = null;
+        invoke();
+      }, remaining);
+    }
+  } as T;
+}


### PR DESCRIPTION
Adds a react query persister that caches and restores the query client from the file system. 

Now that we have this, we might be able to more easily add a watcher to refresh the CLI app itself, though maybe we should then also add in something to prevent the board view (initial view) from refetching its queries, as that'll cause a lot of unnecessary network requests as you're writing code.