### PR TITLE
feat: improve keybind management

### DIFF
--- a/src/api/get-issue-transitions.query.ts
+++ b/src/api/get-issue-transitions.query.ts
@@ -1,4 +1,4 @@
-import { useQuery, useQueryClient } from "@tanstack/react-query";
+import { type QueryClient, useQuery } from "@tanstack/react-query";
 import { z } from "zod";
 import { HOUR, request } from "./request.js";
 
@@ -31,8 +31,10 @@ export const useGetIssueTransitionsQuery = (
   });
 };
 
-export const prefetchIssueTransitions = async (issueId: string) => {
-  const queryClient = useQueryClient();
+export const prefetchIssueTransitions = async (
+  queryClient: QueryClient,
+  issueId: string,
+) => {
   await queryClient.prefetchQuery({
     queryKey: ["transitions"],
     queryFn: () => fetchIssueTransitions(issueId),

--- a/src/api/get-priorities.query.ts
+++ b/src/api/get-priorities.query.ts
@@ -1,4 +1,4 @@
-import { useQuery, useQueryClient } from "@tanstack/react-query";
+import { type QueryClient, useQuery } from "@tanstack/react-query";
 import { z } from "zod";
 import { HOUR, request } from "./request.js";
 
@@ -26,8 +26,10 @@ export const useGetPrioritiesQuery = (projectId: string, enabled = true) => {
   });
 };
 
-export const prefetchPriorities = async (projectId: string) => {
-  const queryClient = useQueryClient();
+export const prefetchPriorities = async (
+  queryClient: QueryClient,
+  projectId: string,
+) => {
   await queryClient.prefetchQuery({
     queryKey: ["priorities"],
     queryFn: () => fetchPriorities(projectId),

--- a/src/api/get-users.query.ts
+++ b/src/api/get-users.query.ts
@@ -1,4 +1,4 @@
-import { useQuery, useQueryClient } from "@tanstack/react-query";
+import { type QueryClient, useQuery } from "@tanstack/react-query";
 import { z } from "zod";
 import { HOUR, request } from "./request.js";
 
@@ -23,8 +23,10 @@ export const useGetUsersQuery = (issueId: string | number) => {
   });
 };
 
-export const prefetchUsers = async (issueId: string | number) => {
-  const queryClient = useQueryClient();
+export const prefetchUsers = async (
+  queryClient: QueryClient,
+  issueId: string | number,
+) => {
   await queryClient.prefetchQuery({
     queryKey: ["users"],
     queryFn: () => fetchUsers(issueId),

--- a/src/api/transition-issue.mutation.ts
+++ b/src/api/transition-issue.mutation.ts
@@ -77,6 +77,7 @@ export const useTransitionIssueMutation = () => {
           if (issueIndex >= 0) {
             store.set(highlightedIssueAtom, {
               id: issues[issueIndex]?.id ?? null,
+              key: issues[issueIndex]?.key ?? null,
               column: columnIndex,
               index: issueIndex,
             });

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -4,6 +4,7 @@ import { Box, Text } from "ink";
 import { Provider as JotaiProvider } from "jotai";
 import { store } from "./atoms/store.js";
 import { BoardView } from "./board-view.js";
+import { GlobalKeybindHandler } from "./keybind-handler.js";
 import { createFilePersister } from "./lib/query-storage-persister.js";
 
 const queryClient = new QueryClient({
@@ -23,6 +24,7 @@ export const App = () => {
         client={queryClient}
         persistOptions={{ persister }}
       >
+        <GlobalKeybindHandler />
         <Box flexDirection="column" width={"100%"} height={"100%"}>
           <Text> JIRA TIME</Text>
           <Box

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -5,6 +5,7 @@ import { Provider as JotaiProvider } from "jotai";
 import { store } from "./atoms/store.js";
 import { BoardView } from "./board-view.js";
 import { GlobalKeybindHandler } from "./keybind-handler.js";
+import { KeybindsDisplay } from "./keybinds-display.js";
 import { createFilePersister } from "./lib/query-storage-persister.js";
 
 const queryClient = new QueryClient({
@@ -34,6 +35,7 @@ export const App = () => {
             flexDirection="column"
           >
             <BoardView />
+            <KeybindsDisplay />
           </Box>
         </Box>
       </PersistQueryClientProvider>

--- a/src/atoms/active-view.atom.ts
+++ b/src/atoms/active-view.atom.ts
@@ -1,0 +1,15 @@
+import { atom } from "jotai";
+
+export const activeViewAtom = atom<string | null>(null);
+
+// Derived atom that keeps track of the previous view
+export const previousViewAtom = atom(
+  (get) => get(activeViewAtom), // Read the current value
+  (get, set, newView: string | null) => {
+    const prev = get(activeViewAtom);
+    set(activeViewAtom, newView);
+    set(prevViewStoreAtom, prev);
+  },
+);
+
+const prevViewStoreAtom = atom<string | null>(null);

--- a/src/atoms/active-view.atom.ts
+++ b/src/atoms/active-view.atom.ts
@@ -2,6 +2,8 @@ import { atom } from "jotai";
 
 export const activeViewAtom = atom<string | null>(null);
 
+const prevViewStoreAtom = atom<string | null>(null);
+
 // Derived atom that keeps track of the previous view
 export const previousViewAtom = atom(
   (get) => get(activeViewAtom), // Read the current value
@@ -11,5 +13,3 @@ export const previousViewAtom = atom(
     set(prevViewStoreAtom, prev);
   },
 );
-
-const prevViewStoreAtom = atom<string | null>(null);

--- a/src/atoms/highlighted-issue.atom.ts
+++ b/src/atoms/highlighted-issue.atom.ts
@@ -4,4 +4,5 @@ export const highlightedIssueAtom = atom<{
   column: number;
   index: number;
   id: null | string;
-}>({ column: 0, index: 0, id: null });
+  key: string | null;
+}>({ column: 0, index: 0, id: null, key: null });

--- a/src/atoms/keybinds.atom.ts
+++ b/src/atoms/keybinds.atom.ts
@@ -2,6 +2,7 @@ import { atom } from "jotai";
 import { atomWithReducer } from "jotai/utils";
 import type { Keybind } from "../lib/keybinds/keybinds.js";
 import { activeViewAtom } from "./active-view.atom.js";
+import { boardSearchStateAtom } from "./board-search.atom.js";
 
 type RegisterKeybind = { type: "register"; keybind: Keybind; view: string };
 
@@ -43,6 +44,10 @@ const keybindReducer = (
 export const keybindReducerAtom = atomWithReducer(
   new Map<string, Keybind[]>(),
   keybindReducer,
+);
+
+export const ignoreKeybindsAtom = atom(
+  (get) => get(boardSearchStateAtom) === "active",
 );
 
 export const activeKeybindsAtom = atom((get) => {

--- a/src/atoms/keybinds.atom.ts
+++ b/src/atoms/keybinds.atom.ts
@@ -1,0 +1,55 @@
+import { atom } from "jotai";
+import { atomWithReducer } from "jotai/utils";
+import type { Keybind } from "../lib/keybinds/keybinds.js";
+
+type RegisterKeybind = { type: "register"; keybind: Keybind };
+
+type UnregisterKeybind = { type: "unregister"; keybind: Keybind };
+
+const keybindReducer = (
+  prev: Keybind[],
+  action: RegisterKeybind | UnregisterKeybind,
+) => {
+  if (action.type === "register") {
+    return [...prev, action.keybind];
+  }
+
+  if (action.type === "unregister") {
+    // Remove the last keybind with the same key
+
+    const lastKeybindIndex = prev
+      .map((k) => k.key)
+      .lastIndexOf(action.keybind.key);
+
+    if (lastKeybindIndex === -1) {
+      return prev;
+    }
+
+    return [
+      ...prev.slice(0, lastKeybindIndex),
+      ...prev.slice(lastKeybindIndex + 1),
+    ];
+  }
+
+  throw new Error("Invalid action type");
+};
+
+export const keybindReducerAtom = atomWithReducer([], keybindReducer);
+
+export const activeKeybindsAtom = atom((get) => get(keybindReducerAtom));
+
+export const keybindsDisplayAtom = atom((get) => {
+  const keybinds = get(activeKeybindsAtom);
+
+  // Only get the last keybinds of each key, as there might be a dialog open with the same keybind as the underlying view
+
+  const keybindsMap = new Map<string, Keybind>(
+    keybinds.map((keybind) => [keybind.key, keybind]),
+  );
+
+  return Array.from(keybindsMap.values()).map(toDisplay).join(" | ");
+});
+
+function toDisplay(keybind: Keybind) {
+  return `${keybind.name}: ${keybind.key}`;
+}

--- a/src/atoms/modals.atom.ts
+++ b/src/atoms/modals.atom.ts
@@ -16,8 +16,8 @@ export const openModal = (modal: keyof ExtractAtomValue<typeof modalsAtom>) => {
   store.set(modalsAtom, (prev) => ({ ...prev, [modal]: true }));
 };
 
-export const closeModal = (
-  modal: keyof ExtractAtomValue<typeof modalsAtom>,
-) => {
+export const closeModal = (modal: ModalKey) => {
   store.set(modalsAtom, (prev) => ({ ...prev, [modal]: false }));
 };
+
+export type ModalKey = keyof ExtractAtomValue<typeof modalsAtom>;

--- a/src/atoms/viewed-issue.atom.ts
+++ b/src/atoms/viewed-issue.atom.ts
@@ -1,0 +1,4 @@
+import { atom } from "jotai";
+
+/** The currently selected issue */
+export const viewedIssueAtom = atom<null | string>(null);

--- a/src/board-view.tsx
+++ b/src/board-view.tsx
@@ -46,6 +46,7 @@ export const BoardView = () => {
   const modals = useAtomValue(modalsAtom);
   const [boardSearch, setBoardSearch] = useAtom(boardSearchAtom);
   const resetBoardSearch = useSetAtom(resetBoardSearchAtom);
+  const hasHighlightedIssue = !!useAtomValue(highlightedIssueAtom).id;
 
   const [searchState, setSearchState] = useAtom(boardSearchStateAtom);
   const [modalIssueId, setModalIssueId] = useState<string | null>(null);
@@ -104,7 +105,9 @@ export const BoardView = () => {
         ...CONFIRM_KEY,
         name: "View issue",
         hidden: true,
-        when: () => store.get(boardSearchStateAtom) !== "active",
+        when: () =>
+          !!store.get(highlightedIssueAtom).id &&
+          store.get(boardSearchStateAtom) !== "active",
         handler: () => {
           const selectedIssue = store.get(highlightedIssueAtom);
 
@@ -213,7 +216,7 @@ export const BoardView = () => {
         ))}
 
       {!!viewedIssue && <ViewIssueModal openModal={onOpenModal} />}
-      {selectUsersModalOpen && (
+      {(hasHighlightedIssue || modalIssueId) && selectUsersModalOpen && (
         <SelectUsersModal
           title={"Select users to show issues from:"}
           selected={filteredUsers.length ? filteredUsers : allUsers}
@@ -223,22 +226,29 @@ export const BoardView = () => {
         />
       )}
 
-      {modals.updatePriority && modalIssueId && (
-        <SelectPriorityModal
-          onClose={() => closeModal("updatePriority")}
-          onSelect={(priority) =>
-            updateIssue({
-              issueId: modalIssueId,
-              fields: {
-                priority: { id: priority.value, name: priority.label },
-              },
-            })
-          }
-        />
+      {modals.updatePriority &&
+        modalIssueId &&
+        (hasHighlightedIssue || modalIssueId) && (
+          <SelectPriorityModal
+            onClose={() => closeModal("updatePriority")}
+            onSelect={(priority) =>
+              updateIssue({
+                issueId: modalIssueId,
+                fields: {
+                  priority: { id: priority.value, name: priority.label },
+                },
+              })
+            }
+          />
+        )}
+      {modals.updateAssignee && (hasHighlightedIssue || modalIssueId) && (
+        <UpdateAssigneeModal issueId={modalIssueId} />
       )}
-      {modals.updateAssignee && <UpdateAssigneeModal issueId={modalIssueId} />}
-      {modals.moveIssue && (
-        <SelectLaneModal onClose={() => closeModal("moveIssue")} />
+      {modals.moveIssue && (hasHighlightedIssue || modalIssueId) && (
+        <SelectLaneModal
+          issueId={modalIssueId}
+          onClose={() => closeModal("moveIssue")}
+        />
       )}
     </>
   );

--- a/src/board-view.tsx
+++ b/src/board-view.tsx
@@ -83,7 +83,7 @@ export const BoardView = () => {
   }, [issues, boardSearch]);
 
   useKeybinds(
-    "BoardView",
+    { view: "BoardView" },
     (register) => {
       register({
         key: "/",

--- a/src/board-view.tsx
+++ b/src/board-view.tsx
@@ -11,7 +11,6 @@ import {
   boardSearchStateAtom,
   resetBoardSearchAtom,
 } from "./atoms/board-search.atom.js";
-import { keybindsDisplayAtom } from "./atoms/keybinds.atom.js";
 import {
   closeModal,
   inputDisabledAtom,
@@ -48,8 +47,6 @@ export const BoardView = () => {
   const searchState = useAtomValue(boardSearchStateAtom);
 
   const queryClient = useQueryClient();
-
-  const keybindsDisplay = useAtomValue(keybindsDisplayAtom);
 
   const usersById: Map<string, JiraUser> = useMemo(() => {
     if (!issues) {
@@ -174,7 +171,6 @@ export const BoardView = () => {
         issues &&
         (searchState === "disabled" ? (
           <Box width={"100%"} justifyContent="space-between">
-            <Text>{` ${keybindsDisplay}`}</Text>
             {isFetching > 0 && <Spinner label="Fetching" />}
           </Box>
         ) : (

--- a/src/board-view.tsx
+++ b/src/board-view.tsx
@@ -86,6 +86,7 @@ export const BoardView = () => {
   }, [issues, boardSearch]);
 
   useKeybinds(
+    "BoardView",
     (register) => {
       register({
         key: "/",

--- a/src/board-view.tsx
+++ b/src/board-view.tsx
@@ -189,7 +189,6 @@ export const BoardView = () => {
       {selectUsersModalOpen && (
         <SelectUsersModal
           title={"Select users to show issues from:"}
-          footer={"Select: <space> | Confirm: <return> | Cancel: q"}
           selected={filteredUsers.length ? filteredUsers : allUsers}
           options={allUsers}
           onSelect={(selectedUsers) => setFilteredUsers(selectedUsers)}

--- a/src/board.tsx
+++ b/src/board.tsx
@@ -8,6 +8,7 @@ import { boardSearchStateAtom } from "./atoms/board-search.atom.js";
 import { highlightedIssueAtom } from "./atoms/highlighted-issue.atom.js";
 import { inputDisabledAtom } from "./atoms/modals.atom.js";
 import { scrollOffsetAtom } from "./atoms/scroll-offset.atom.js";
+import { viewedIssueAtom } from "./atoms/viewed-issue.atom.js";
 import { Column } from "./column.js";
 import { log } from "./lib/log.js";
 import type { JiraUser } from "./types/jira-user.js";
@@ -75,6 +76,7 @@ export const Board = ({
   const [highlightedIssue, setHighlightedIssue] = useAtom(highlightedIssueAtom);
   const inputDisabled = useAtomValue(inputDisabledAtom);
   const isBoardSearchActive = useAtomValue(boardSearchStateAtom) === "active";
+  const hasViewedIssue = useAtomValue(viewedIssueAtom) !== null;
 
   const columns = boardConfiguration.columnConfig.columns.map((c) => c.name);
 
@@ -173,7 +175,8 @@ export const Board = ({
   );
 
   useInput((input, key) => {
-    if (inputDisabled || isBoardSearchActive || ignoreInput) return;
+    if (inputDisabled || isBoardSearchActive || ignoreInput || hasViewedIssue)
+      return;
 
     // TODO: not ideal that these are in their own useInput, but might be necessary due to the moving of the board, etc.
     // Maybe extract to a separate `useKeyboardNavigation` hook with callbacks for each direction?

--- a/src/components/search.tsx
+++ b/src/components/search.tsx
@@ -12,15 +12,21 @@ type SearchProps = {
 export const SearchInput = ({
   state,
   onResetSearch,
+  onConfirmSearch,
   ...searchProps
 }: {
   state: "search" | "result";
   onResetSearch: () => void;
+  onConfirmSearch: () => void;
 } & SearchProps) => {
   useInput((_, key) => {
     if (key.escape && state === "result") {
       onResetSearch();
       return;
+    }
+
+    if (key.return && state === "search") {
+      onConfirmSearch();
     }
   });
 

--- a/src/hooks/use-keybinds.ts
+++ b/src/hooks/use-keybinds.ts
@@ -1,37 +1,45 @@
+import { useAtom } from "jotai";
 import { useCallback, useEffect, useRef } from "react";
+import { previousViewAtom } from "../atoms/active-view.atom.js";
 import type { Keybind } from "../lib/keybinds/keybinds.js";
 import { registerKeybind as registerKeybindFn } from "../lib/keybinds/keybinds.js";
 
 type UseKeybinds = (
+  view: string,
   callback: (register: (keybind: Keybind) => void) => void,
   deps: unknown[],
 ) => void;
 
-export const useKeybinds: UseKeybinds = (callback, deps) => {
+export const useKeybinds: UseKeybinds = (view, callback, deps) => {
   const unregisterKeybindFnsByRegistrar = useRef(
     new Map<string, ReturnType<typeof registerKeybindFn>>(),
   );
+  const [prevView, setActiveView] = useAtom(previousViewAtom); // Updates both active & previous views
 
   // Wrap the callback in useCallback to prevent it from being called on every render, since the callback itself probably isn't wrapped
   const actualCallback = useCallback(callback, deps);
 
   // Prevent duplicate keybinds from being registered when the component re-renders
-  const registerFn = useCallback((keybind: Keybind) => {
-    const keybindHash = hash(keybind);
-    const seen = unregisterKeybindFnsByRegistrar.current.has(keybindHash);
-    if (!seen) {
-      unregisterKeybindFnsByRegistrar.current.set(
-        keybindHash,
-        registerKeybindFn(keybind),
-      );
-    }
-  }, []);
-
-  useEffect(() => {
-    return () => {
-      for (const unregisterKeybind of unregisterKeybindFnsByRegistrar.current.values()) {
-        unregisterKeybind();
+  const registerFn = useCallback(
+    (keybind: Keybind) => {
+      const keybindHash = hash(keybind);
+      const seen = unregisterKeybindFnsByRegistrar.current.has(keybindHash);
+      if (!seen) {
+        unregisterKeybindFnsByRegistrar.current.set(
+          keybindHash,
+          registerKeybindFn(view, keybind),
+        );
       }
+    },
+    [view],
+  );
+
+  // biome-ignore lint/correctness/useExhaustiveDependencies: only runs at startup
+  useEffect(() => {
+    setActiveView(view);
+
+    return () => {
+      setActiveView(prevView);
     };
   }, []);
 

--- a/src/hooks/use-keybinds.ts
+++ b/src/hooks/use-keybinds.ts
@@ -57,7 +57,6 @@ export const useKeybinds: UseKeybinds = (options, callback, deps) => {
     };
   }, []);
 
-  // Unregister all keybinds when the component unmounts
   useEffect(() => {
     actualCallback(registerFn);
   }, [registerFn, actualCallback, ...deps]);

--- a/src/hooks/use-keybinds.ts
+++ b/src/hooks/use-keybinds.ts
@@ -66,6 +66,7 @@ export const useKeybinds: UseKeybinds = (options, callback, deps) => {
 function hash(keybind: Keybind) {
   return JSON.stringify({
     key: keybind.key,
+    name: keybind.name, // There might be multiple keybinds with the same key (e.g. for different conditions), so include the name
     modifiers: (keybind.modifiers ?? []).toSorted(),
   });
 }

--- a/src/hooks/use-keybinds.ts
+++ b/src/hooks/use-keybinds.ts
@@ -1,0 +1,49 @@
+import { useCallback, useEffect, useRef } from "react";
+import type { Keybind } from "../lib/keybinds/keybinds.js";
+import { registerKeybind as registerKeybindFn } from "../lib/keybinds/keybinds.js";
+
+type UseKeybinds = (
+  callback: (register: (keybind: Keybind) => void) => void,
+  deps: unknown[],
+) => void;
+
+export const useKeybinds: UseKeybinds = (callback, deps) => {
+  const unregisterKeybindFnsByRegistrar = useRef(
+    new Map<string, ReturnType<typeof registerKeybindFn>>(),
+  );
+
+  // Wrap the callback in useCallback to prevent it from being called on every render, since the callback itself probably isn't wrapped
+  const actualCallback = useCallback(callback, deps);
+
+  // Prevent duplicate keybinds from being registered when the component re-renders
+  const registerFn = useCallback((keybind: Keybind) => {
+    const keybindHash = hash(keybind);
+    const seen = unregisterKeybindFnsByRegistrar.current.has(keybindHash);
+    if (!seen) {
+      unregisterKeybindFnsByRegistrar.current.set(
+        keybindHash,
+        registerKeybindFn(keybind),
+      );
+    }
+  }, []);
+
+  useEffect(() => {
+    return () => {
+      for (const unregisterKeybind of unregisterKeybindFnsByRegistrar.current.values()) {
+        unregisterKeybind();
+      }
+    };
+  }, []);
+
+  // Unregister all keybinds when the component unmounts
+  useEffect(() => {
+    actualCallback(registerFn);
+  }, [registerFn, actualCallback, ...deps]);
+};
+
+function hash(keybind: Keybind) {
+  return JSON.stringify({
+    key: keybind.key,
+    modifiers: keybind.modifiers ?? [],
+  });
+}

--- a/src/hooks/use-keybinds.ts
+++ b/src/hooks/use-keybinds.ts
@@ -66,6 +66,6 @@ export const useKeybinds: UseKeybinds = (options, callback, deps) => {
 function hash(keybind: Keybind) {
   return JSON.stringify({
     key: keybind.key,
-    modifiers: keybind.modifiers ?? [],
+    modifiers: (keybind.modifiers ?? []).toSorted(),
   });
 }

--- a/src/hooks/use-viewed-issue.ts
+++ b/src/hooks/use-viewed-issue.ts
@@ -1,0 +1,17 @@
+import { useQueryClient } from "@tanstack/react-query";
+import { useAtomValue } from "jotai";
+import type { Issue } from "../api/get-issues.query.js";
+import { viewedIssueAtom } from "../atoms/viewed-issue.atom.js";
+
+export const useViewedIssue = () => {
+  const queryClient = useQueryClient();
+  const issues = queryClient.getQueryData(["issues"]) as readonly Issue[];
+
+  const viewedIssueId = useAtomValue(viewedIssueAtom);
+
+  const issue = issues?.find(
+    (issue) => issue.id === viewedIssueId || issue.key === viewedIssueId,
+  );
+
+  return issue ?? null;
+};

--- a/src/keybind-handler.tsx
+++ b/src/keybind-handler.tsx
@@ -1,21 +1,49 @@
-import { useInput } from "ink";
+import { type Key, useInput } from "ink";
 import { useAtomValue } from "jotai";
 import { activeKeybindsAtom } from "./atoms/keybinds.atom.js";
+import type { Keybind } from "./lib/keybinds/keybinds.js";
 
 export const GlobalKeybindHandler = () => {
   const keybinds = useAtomValue(activeKeybindsAtom);
 
   useInput((input, key) => {
     for (const keybind of keybinds) {
-      const hasModifier =
-        !keybind.modifiers ||
-        keybind.modifiers.every((modifier) => !!key[modifier]);
-
-      if (input === keybind.key && hasModifier) {
+      if (shouldTrigger(keybind, input, key)) {
         keybind.handler();
       }
     }
   });
 
   return null;
+};
+
+const shouldTrigger = (
+  keybind: Pick<Keybind, "key" | "modifiers" | "aliases">,
+  input: string,
+  key: Key,
+) => {
+  const isMatchingBase =
+    keybind.key === input &&
+    (!keybind.modifiers?.length ||
+      keybind.modifiers.every((modifier) => !!key[modifier]));
+
+  if (isMatchingBase) {
+    return true;
+  }
+
+  if (!keybind.aliases) {
+    return false;
+  }
+
+  return keybind.aliases.some((alias) => {
+    if (typeof alias === "string") {
+      return alias === input;
+    }
+
+    return (
+      alias.key === input &&
+      (!alias.modifiers?.length ||
+        alias.modifiers.every((modifier) => !!key[modifier]))
+    );
+  });
 };

--- a/src/keybind-handler.tsx
+++ b/src/keybind-handler.tsx
@@ -14,6 +14,10 @@ export const GlobalKeybindHandler = () => {
   useInput(
     (input, key) => {
       for (const keybind of keybinds) {
+        if (keybind.when && !keybind.when()) {
+          continue;
+        }
+
         if (shouldTrigger(keybind, input, key)) {
           keybind.handler();
         }

--- a/src/keybind-handler.tsx
+++ b/src/keybind-handler.tsx
@@ -1,0 +1,21 @@
+import { useInput } from "ink";
+import { useAtomValue } from "jotai";
+import { activeKeybindsAtom } from "./atoms/keybinds.atom.js";
+
+export const GlobalKeybindHandler = () => {
+  const keybinds = useAtomValue(activeKeybindsAtom);
+
+  useInput((input, key) => {
+    for (const keybind of keybinds) {
+      const hasModifier =
+        !keybind.modifiers ||
+        keybind.modifiers.every((modifier) => !!key[modifier]);
+
+      if (input === keybind.key && hasModifier) {
+        keybind.handler();
+      }
+    }
+  });
+
+  return null;
+};

--- a/src/keybind-handler.tsx
+++ b/src/keybind-handler.tsx
@@ -1,18 +1,26 @@
 import { type Key, useInput } from "ink";
 import { useAtomValue } from "jotai";
-import { activeKeybindsAtom } from "./atoms/keybinds.atom.js";
+import {
+  activeKeybindsAtom,
+  ignoreKeybindsAtom,
+} from "./atoms/keybinds.atom.js";
 import type { Keybind } from "./lib/keybinds/keybinds.js";
 
 export const GlobalKeybindHandler = () => {
   const keybinds = useAtomValue(activeKeybindsAtom);
 
-  useInput((input, key) => {
-    for (const keybind of keybinds) {
-      if (shouldTrigger(keybind, input, key)) {
-        keybind.handler();
+  const ignoreInputs = useAtomValue(ignoreKeybindsAtom);
+
+  useInput(
+    (input, key) => {
+      for (const keybind of keybinds) {
+        if (shouldTrigger(keybind, input, key)) {
+          keybind.handler();
+        }
       }
-    }
-  });
+    },
+    { isActive: !ignoreInputs },
+  );
 
   return null;
 };

--- a/src/keybind-handler.tsx
+++ b/src/keybind-handler.tsx
@@ -23,7 +23,7 @@ const shouldTrigger = (
   key: Key,
 ) => {
   const isMatchingBase =
-    keybind.key === input &&
+    resolveKey(keybind.key) === input &&
     (!keybind.modifiers?.length ||
       keybind.modifiers.every((modifier) => !!key[modifier]));
 
@@ -37,13 +37,23 @@ const shouldTrigger = (
 
   return keybind.aliases.some((alias) => {
     if (typeof alias === "string") {
-      return alias === input;
+      return resolveKey(alias) === input;
     }
 
     return (
-      alias.key === input &&
+      resolveKey(alias.key) === input &&
       (!alias.modifiers?.length ||
         alias.modifiers.every((modifier) => !!key[modifier]))
     );
   });
+};
+
+const resolveKey = (key: string) => {
+  if (key === "<space>") return " ";
+
+  if (key === "<enter>" || key === "<return>" || key === "<CR>") return "\r";
+
+  if (key === "<esc>") return "";
+
+  return key;
 };

--- a/src/keybinds-display.tsx
+++ b/src/keybinds-display.tsx
@@ -1,0 +1,22 @@
+import { Box, Text } from "ink";
+import { useAtomValue } from "jotai";
+import { keybindsDisplayAtom } from "./atoms/keybinds.atom.js";
+
+export const KeybindsDisplay = () => {
+  const keybindsDisplay = useAtomValue(keybindsDisplayAtom);
+
+  return (
+    <Box
+      width="100%"
+      margin={0}
+      padding={0}
+      borderLeft={false}
+      borderBottom={false}
+      borderRight={false}
+      borderStyle="round"
+      borderColor="white"
+    >
+      <Text color="blueBright">{` ${keybindsDisplay}`}</Text>
+    </Box>
+  );
+};

--- a/src/lib/keybinds/keybinds.ts
+++ b/src/lib/keybinds/keybinds.ts
@@ -2,11 +2,14 @@ import type { Key } from "ink";
 import { keybindReducerAtom } from "../../atoms/keybinds.atom.js";
 import { store } from "../../atoms/store.js";
 
+type Alias = string | { key: string; modifiers?: ReadonlyArray<keyof Key> };
+
 export type Keybind = {
   key: string;
   modifiers?: ReadonlyArray<keyof Key>;
-  handler: () => void;
+  aliases?: readonly Alias[];
   name: string;
+  handler: () => void;
   description?: string;
 };
 

--- a/src/lib/keybinds/keybinds.ts
+++ b/src/lib/keybinds/keybinds.ts
@@ -1,0 +1,23 @@
+import type { Key } from "ink";
+import { keybindReducerAtom } from "../../atoms/keybinds.atom.js";
+import { store } from "../../atoms/store.js";
+
+export type Keybind = {
+  key: string;
+  modifiers?: ReadonlyArray<keyof Key>;
+  handler: () => void;
+  name: string;
+  description?: string;
+};
+
+export const registerKeybind = (keybind: Keybind) => {
+  store.set(keybindReducerAtom, { type: "register", keybind });
+
+  return () => {
+    unregisterKeybind(keybind);
+  };
+};
+
+export const unregisterKeybind = (keybind: Keybind) => {
+  store.set(keybindReducerAtom, { type: "unregister", keybind });
+};

--- a/src/lib/keybinds/keybinds.ts
+++ b/src/lib/keybinds/keybinds.ts
@@ -11,16 +11,13 @@ export type Keybind = {
   name: string;
   handler: () => void;
   description?: string;
+  hidden?: boolean;
 };
 
-export const registerKeybind = (keybind: Keybind) => {
-  store.set(keybindReducerAtom, { type: "register", keybind });
+export const registerKeybind = (view: string, keybind: Keybind) => {
+  store.set(keybindReducerAtom, { type: "register", keybind, view });
 
   return () => {
-    unregisterKeybind(keybind);
+    store.set(keybindReducerAtom, { type: "unregister", keybind, view });
   };
-};
-
-export const unregisterKeybind = (keybind: Keybind) => {
-  store.set(keybindReducerAtom, { type: "unregister", keybind });
 };

--- a/src/lib/keybinds/keybinds.ts
+++ b/src/lib/keybinds/keybinds.ts
@@ -10,6 +10,7 @@ export type Keybind = {
   aliases?: readonly Alias[];
   name: string;
   handler: () => void;
+  when?: () => boolean;
   description?: string;
   hidden?: boolean;
 };

--- a/src/lib/keybinds/keys.ts
+++ b/src/lib/keybinds/keys.ts
@@ -39,11 +39,6 @@ export const CLOSE_KEY = {
   aliases: [{ key: "", modifiers: ["escape"] }],
 } satisfies Partial<Keybind>;
 
-export const ESCAPE_KEY = {
-  key: "<esc>",
-  aliases: [{ key: "", modifiers: ["escape"] }],
-} satisfies Partial<Keybind>;
-
 export const SPACE_KEY = {
   key: "<space>",
 } satisfies Partial<Keybind>;

--- a/src/lib/keybinds/keys.ts
+++ b/src/lib/keybinds/keys.ts
@@ -1,0 +1,49 @@
+import type { Keybind } from "./keybinds.js";
+
+export const UP_KEY = {
+  key: "k",
+  aliases: [
+    { key: "", modifiers: ["upArrow"] },
+    { key: "p", modifiers: ["ctrl"] },
+  ],
+} satisfies Partial<Keybind>;
+
+export const DOWN_KEY = {
+  key: "j",
+  aliases: [
+    { key: "", modifiers: ["downArrow"] },
+    { key: "n", modifiers: ["ctrl"] },
+  ],
+} satisfies Partial<Keybind>;
+
+export const LEFT_KEY = {
+  key: "h",
+  aliases: [{ key: "", modifiers: ["leftArrow"] }],
+} satisfies Partial<Keybind>;
+
+export const RIGHT_KEY = {
+  key: "l",
+  aliases: [{ key: "", modifiers: ["rightArrow"] }],
+} satisfies Partial<Keybind>;
+
+export const CONFIRM_KEY = {
+  key: "<return>",
+  aliases: [
+    { key: "", modifiers: ["return"] },
+    { key: "y", modifiers: ["ctrl"] },
+  ],
+} satisfies Partial<Keybind>;
+
+export const CLOSE_KEY = {
+  key: "q",
+  aliases: [{ key: "", modifiers: ["escape"] }],
+} satisfies Partial<Keybind>;
+
+export const ESCAPE_KEY = {
+  key: "<esc>",
+  aliases: [{ key: "", modifiers: ["escape"] }],
+} satisfies Partial<Keybind>;
+
+export const SPACE_KEY = {
+  key: "<space>",
+} satisfies Partial<Keybind>;

--- a/src/modals/select-lane-modal.tsx
+++ b/src/modals/select-lane-modal.tsx
@@ -60,9 +60,7 @@ export const SelectLaneModal = ({
         },
       }))}
       title={"Select lane"}
-      footer={" Confirm: <return> | Cancel: q"}
       selected={selectedTransition!.id}
-      initialFocusOnSelected
       onSelect={(choice: Option) => {
         if (choice.value !== selectedTransition!.id) {
           transitionIssue({

--- a/src/modals/select-lane-modal.tsx
+++ b/src/modals/select-lane-modal.tsx
@@ -11,16 +11,18 @@ import { SelectModal } from "./select-modal.js";
 
 export const SelectLaneModal = ({
   onClose,
+  issueId: _issueId,
 }: {
   onClose: () => void;
+  issueId?: string | null;
 }) => {
   const { mutate: transitionIssue } = useTransitionIssueMutation();
-  const highlightedIssue = useAtomValue(highlightedIssueAtom);
+  const issueId = _issueId ?? useAtomValue(highlightedIssueAtom).id;
   const queryClient = useQueryClient();
   const issues = queryClient.getQueryData(["issues"]) as Issue[];
   const { data: board } = useBoardQuery();
 
-  const issue = issues.find((issue) => issue.id === highlightedIssue.id)!;
+  const issue = issues.find((issue) => issue.id === issueId)!;
 
   const { data: transitions } = useGetIssueTransitionsQuery(
     issue?.id!,

--- a/src/modals/select-lane-modal.tsx
+++ b/src/modals/select-lane-modal.tsx
@@ -11,13 +11,13 @@ import { SelectModal } from "./select-modal.js";
 
 export const SelectLaneModal = ({
   onClose,
-  issueId: _issueId,
+  issueId: issueIdOverride,
 }: {
   onClose: () => void;
   issueId?: string | null;
 }) => {
   const { mutate: transitionIssue } = useTransitionIssueMutation();
-  const issueId = _issueId ?? useAtomValue(highlightedIssueAtom).id;
+  const issueId = issueIdOverride ?? useAtomValue(highlightedIssueAtom).id;
   const queryClient = useQueryClient();
   const issues = queryClient.getQueryData(["issues"]) as Issue[];
   const { data: board } = useBoardQuery();

--- a/src/modals/select-priority-modal.tsx
+++ b/src/modals/select-priority-modal.tsx
@@ -37,7 +37,6 @@ export const SelectPriorityModal = ({
         color: priority.statusColor,
       }))}
       title={"Select priority"}
-      footer={" Confirm: <return> | Cancel: q"}
       selected={issue.fields.priority.id}
       onSelect={(choice: Option) => {
         if (choice.value !== issue.fields.priority.id) {

--- a/src/modals/select-user-modal.tsx
+++ b/src/modals/select-user-modal.tsx
@@ -38,7 +38,6 @@ export const SelectUserModal = ({
           return a.label.localeCompare(b.label);
         })}
       title={"Select user"}
-      footer={" Confirm: <return> | Cancel: q"}
       selected={selectedUserId}
       onSelect={onSelect}
       onClose={onClose}

--- a/src/modals/select-users-modal.tsx
+++ b/src/modals/select-users-modal.tsx
@@ -8,6 +8,7 @@ import { useStdoutDimensions } from "../useStdoutDimensions.js";
 
 const focusedAtom = atom(0);
 const selectedAtom = atom<number[]>([]);
+const optionsAtom = atom<JiraUser[]>([]);
 
 export const SelectUsersModal = ({
   title,
@@ -33,7 +34,9 @@ export const SelectUsersModal = ({
         .map((option, i) => (initialSelected.includes(option) ? i : -1))
         .filter((i) => i !== -1),
     );
-  }, [setSelected, initialSelected, options]);
+
+    store.set(optionsAtom, options);
+  }, [setSelected, initialSelected, options, store.set]);
 
   const maxLength = Math.max(
     ...options.map((option) => option.displayName.length + 6),
@@ -41,7 +44,7 @@ export const SelectUsersModal = ({
   );
 
   useKeybinds(
-    "SelectUsersModal",
+    { view: "SelectUsersModal", unregister: true },
     (register) => {
       register({
         key: "j",
@@ -52,7 +55,11 @@ export const SelectUsersModal = ({
           { key: "n", modifiers: ["ctrl"] },
         ],
         handler: () => {
-          setFocused((prev) => Math.min(options.length - 1, prev + 1));
+          const options = store.get(optionsAtom);
+
+          store.set(focusedAtom, (prev) =>
+            Math.min(options.length - 1, prev + 1),
+          );
         },
       });
 
@@ -64,7 +71,9 @@ export const SelectUsersModal = ({
           { key: "", modifiers: ["upArrow"] },
           { key: "p", modifiers: ["ctrl"] },
         ],
-        handler: () => setFocused((prev) => Math.max(0, prev - 1)),
+        handler: () => {
+          store.set(focusedAtom, (prev) => Math.max(0, prev - 1));
+        },
       });
 
       register({
@@ -94,6 +103,7 @@ export const SelectUsersModal = ({
         ],
         handler: () => {
           const selectedValue = store.get(selectedAtom);
+          const options = store.get(optionsAtom);
           onSelect(
             selectedValue.length
               ? selectedValue.map((index) => options[index]!)

--- a/src/modals/select-users-modal.tsx
+++ b/src/modals/select-users-modal.tsx
@@ -1,41 +1,108 @@
-import { Box, Text, useInput } from "ink";
-import { useState } from "react";
+import { Box, Text } from "ink";
+import { atom, useAtom } from "jotai";
+import { useStore } from "jotai";
+import { useEffect } from "react";
 import { useKeybinds } from "../hooks/use-keybinds.js";
 import type { JiraUser } from "../types/jira-user.js";
 import { useStdoutDimensions } from "../useStdoutDimensions.js";
 
+const focusedAtom = atom(0);
+const selectedAtom = atom<number[]>([]);
+
 export const SelectUsersModal = ({
   title,
-  footer,
   options,
   selected: initialSelected,
   onSelect,
   onClose,
 }: {
   title: string;
-  footer: string;
   options: JiraUser[];
   selected: JiraUser[];
   onSelect: (selected: JiraUser[]) => void;
   onClose: () => void;
 }) => {
-  const [focused, setFocused] = useState(0);
-  const [selected, setSelected] = useState<number[]>(
-    options
-      .map((option, i) => (initialSelected.includes(option) ? i : -1))
-      .filter((i) => i !== -1),
-  );
+  const [focused, setFocused] = useAtom(focusedAtom);
+  const [selected, setSelected] = useAtom(selectedAtom);
   const [columns, rows] = useStdoutDimensions();
+  const store = useStore();
+
+  useEffect(() => {
+    setSelected(
+      options
+        .map((option, i) => (initialSelected.includes(option) ? i : -1))
+        .filter((i) => i !== -1),
+    );
+  }, [setSelected, initialSelected, options]);
 
   const maxLength = Math.max(
     ...options.map((option) => option.displayName.length + 6),
     title.length + 6,
-    footer.length + 6,
   );
 
   useKeybinds(
     "SelectUsersModal",
     (register) => {
+      register({
+        key: "j",
+        hidden: true,
+        name: "Down",
+        aliases: [
+          { key: "", modifiers: ["downArrow"] },
+          { key: "n", modifiers: ["ctrl"] },
+        ],
+        handler: () => {
+          setFocused((prev) => Math.min(options.length - 1, prev + 1));
+        },
+      });
+
+      register({
+        key: "k",
+        hidden: true,
+        name: "Up",
+        aliases: [
+          { key: "", modifiers: ["upArrow"] },
+          { key: "p", modifiers: ["ctrl"] },
+        ],
+        handler: () => setFocused((prev) => Math.max(0, prev - 1)),
+      });
+
+      register({
+        key: "<space>",
+        name: "Select",
+        handler: () => {
+          const focusedValue = store.get(focusedAtom);
+          const selectedValue = store.get(selectedAtom);
+
+          if (selectedValue.includes(focusedValue)) {
+            store.set(
+              selectedAtom,
+              selectedValue.filter((s) => s !== focusedValue),
+            );
+          } else {
+            store.set(selectedAtom, [...selectedValue, focusedValue]);
+          }
+        },
+      });
+
+      register({
+        key: "<return>",
+        name: "Select",
+        aliases: [
+          { key: "", modifiers: ["return"] },
+          { key: "y", modifiers: ["ctrl"] },
+        ],
+        handler: () => {
+          const selectedValue = store.get(selectedAtom);
+          onSelect(
+            selectedValue.length
+              ? selectedValue.map((index) => options[index]!)
+              : options,
+          );
+          onClose();
+        },
+      });
+
       register({
         key: "q",
         name: "Close",
@@ -45,25 +112,6 @@ export const SelectUsersModal = ({
     },
     [],
   );
-
-  useInput((input, key) => {
-    if (input === "j" || key.downArrow || (key.ctrl && input === "n")) {
-      setFocused(Math.min(options.length - 1, focused + 1));
-    } else if (input === "k" || key.upArrow || (key.ctrl && input === "p")) {
-      setFocused(Math.max(0, focused - 1));
-    } else if (input === " ") {
-      if (selected.includes(focused)) {
-        setSelected((selected) => selected.filter((s) => s !== focused));
-      } else {
-        setSelected((selected) => [...selected, focused]);
-      }
-    } else if (key.return || (key.ctrl && input === "y")) {
-      onSelect(
-        selected.length ? selected.map((index) => options[index]!) : options,
-      );
-      onClose();
-    }
-  });
 
   return (
     <Box
@@ -101,10 +149,6 @@ export const SelectUsersModal = ({
         );
       })}
       <Text>{"".padEnd(maxLength, " ")}</Text>
-      <Text color={"blueBright"}>
-        {"   "}
-        {footer.padEnd(maxLength - 3, " ")}
-      </Text>
     </Box>
   );
 };

--- a/src/modals/select-users-modal.tsx
+++ b/src/modals/select-users-modal.tsx
@@ -3,6 +3,13 @@ import { atom, useAtom } from "jotai";
 import { useStore } from "jotai";
 import { useEffect } from "react";
 import { useKeybinds } from "../hooks/use-keybinds.js";
+import {
+  CLOSE_KEY,
+  CONFIRM_KEY,
+  DOWN_KEY,
+  SPACE_KEY,
+  UP_KEY,
+} from "../lib/keybinds/keys.js";
 import type { JiraUser } from "../types/jira-user.js";
 import { useStdoutDimensions } from "../useStdoutDimensions.js";
 
@@ -47,13 +54,9 @@ export const SelectUsersModal = ({
     { view: "SelectUsersModal", unregister: true },
     (register) => {
       register({
-        key: "j",
+        ...DOWN_KEY,
         hidden: true,
         name: "Down",
-        aliases: [
-          { key: "", modifiers: ["downArrow"] },
-          { key: "n", modifiers: ["ctrl"] },
-        ],
         handler: () => {
           const options = store.get(optionsAtom);
 
@@ -64,20 +67,16 @@ export const SelectUsersModal = ({
       });
 
       register({
-        key: "k",
+        ...UP_KEY,
         hidden: true,
         name: "Up",
-        aliases: [
-          { key: "", modifiers: ["upArrow"] },
-          { key: "p", modifiers: ["ctrl"] },
-        ],
         handler: () => {
           store.set(focusedAtom, (prev) => Math.max(0, prev - 1));
         },
       });
 
       register({
-        key: "<space>",
+        ...SPACE_KEY,
         name: "Select",
         handler: () => {
           const focusedValue = store.get(focusedAtom);
@@ -95,12 +94,8 @@ export const SelectUsersModal = ({
       });
 
       register({
-        key: "<return>",
+        ...CONFIRM_KEY,
         name: "Select",
-        aliases: [
-          { key: "", modifiers: ["return"] },
-          { key: "y", modifiers: ["ctrl"] },
-        ],
         handler: () => {
           const selectedValue = store.get(selectedAtom);
           const options = store.get(optionsAtom);
@@ -114,9 +109,8 @@ export const SelectUsersModal = ({
       });
 
       register({
-        key: "q",
+        ...CLOSE_KEY,
         name: "Close",
-        aliases: [{ key: "", modifiers: ["escape"] }],
         handler: onClose,
       });
     },

--- a/src/modals/select-users-modal.tsx
+++ b/src/modals/select-users-modal.tsx
@@ -1,5 +1,6 @@
 import { Box, Text, useInput } from "ink";
 import { useState } from "react";
+import { useKeybinds } from "../hooks/use-keybinds.js";
 import type { JiraUser } from "../types/jira-user.js";
 import { useStdoutDimensions } from "../useStdoutDimensions.js";
 
@@ -32,6 +33,19 @@ export const SelectUsersModal = ({
     footer.length + 6,
   );
 
+  useKeybinds(
+    "SelectUsersModal",
+    (register) => {
+      register({
+        key: "q",
+        name: "Close",
+        aliases: [{ key: "", modifiers: ["escape"] }],
+        handler: onClose,
+      });
+    },
+    [],
+  );
+
   useInput((input, key) => {
     if (input === "j" || key.downArrow || (key.ctrl && input === "n")) {
       setFocused(Math.min(options.length - 1, focused + 1));
@@ -47,8 +61,6 @@ export const SelectUsersModal = ({
       onSelect(
         selected.length ? selected.map((index) => options[index]!) : options,
       );
-      onClose();
-    } else if (input === "q" || key.escape) {
       onClose();
     }
   });

--- a/src/modals/update-assignee.modal.tsx
+++ b/src/modals/update-assignee.modal.tsx
@@ -6,15 +6,19 @@ import { highlightedIssueAtom } from "../atoms/highlighted-issue.atom.js";
 import { closeModal } from "../atoms/modals.atom.js";
 import { SelectUserModal } from "./select-user-modal.js";
 
-export const UpdateAssigneeModal = () => {
-  const highlightedIssue = useAtomValue(highlightedIssueAtom);
+export const UpdateAssigneeModal = ({
+  issueId: _issueId,
+}: { issueId?: string | null }) => {
+  const issueId = _issueId ?? useAtomValue(highlightedIssueAtom)?.id;
   const { mutate: updateIssue } = useUpdateIssueMutation();
   const queryClient = useQueryClient();
   const issues = queryClient.getQueryData(["issues"]) as Issue[];
 
-  if (!issues) return <></>;
+  if (!issues) {
+    return null;
+  }
 
-  const issue = issues.find((issue) => issue.id === highlightedIssue.id)!;
+  const issue = issues.find((issue) => issue.id === issueId)!;
 
   return (
     <SelectUserModal

--- a/src/modals/update-assignee.modal.tsx
+++ b/src/modals/update-assignee.modal.tsx
@@ -7,9 +7,9 @@ import { closeModal } from "../atoms/modals.atom.js";
 import { SelectUserModal } from "./select-user-modal.js";
 
 export const UpdateAssigneeModal = ({
-  issueId: _issueId,
+  issueId: issueIdOverride,
 }: { issueId?: string | null }) => {
-  const issueId = _issueId ?? useAtomValue(highlightedIssueAtom)?.id;
+  const issueId = issueIdOverride ?? useAtomValue(highlightedIssueAtom)?.id;
   const { mutate: updateIssue } = useUpdateIssueMutation();
   const queryClient = useQueryClient();
   const issues = queryClient.getQueryData(["issues"]) as Issue[];

--- a/src/modals/view-issue-modal.tsx
+++ b/src/modals/view-issue-modal.tsx
@@ -7,8 +7,7 @@ import { prefetchIssueTransitions } from "../api/get-issue-transitions.query.js"
 import type { Issue } from "../api/get-issues.query.js";
 import { prefetchPriorities } from "../api/get-priorities.query.js";
 import { prefetchUsers } from "../api/get-users.query.js";
-import { useUpdateIssueMutation } from "../api/update-issue.mutation.js";
-import { closeModal, modalsAtom, openModal } from "../atoms/modals.atom.js";
+import type { ModalKey } from "../atoms/modals.atom.js";
 import { viewedIssueAtom } from "../atoms/viewed-issue.atom.js";
 import { env } from "../env.js";
 import { useKeybinds } from "../hooks/use-keybinds.js";
@@ -20,7 +19,6 @@ import { CLOSE_KEY, DOWN_KEY, UP_KEY } from "../lib/keybinds/keys.js";
 import { openIssueInBrowser } from "../lib/utils/openIssueInBrowser.js";
 import { PaddedText } from "../padded-text.js";
 import { useStdoutDimensions } from "../useStdoutDimensions.js";
-import { SelectPriorityModal } from "./select-priority-modal.js";
 
 const issueAtom = atom<Issue | null>(null);
 const topOffsetAtom = atom(0);
@@ -50,16 +48,17 @@ const MAX_LINE_WIDTH = 119;
 const SMALL_SCROLL_INCREMENT = 3;
 const LARGE_SCROLL_INCREMENT = 10;
 
-export const ViewIssueModal = () => {
+export const ViewIssueModal = ({
+  openModal,
+}: {
+  openModal: (type: ModalKey, issueId: string) => void;
+}) => {
   const issue = useViewedIssue();
   const queryClient = useQueryClient();
-
-  const { mutate: updateIssue } = useUpdateIssueMutation();
 
   const [columns, rows] = useStdoutDimensions();
   const topOffset = useAtomValue(topOffsetAtom);
   const description = useAtomValue(issueDescriptionAtom);
-  const modals = useAtomValue(modalsAtom);
   const store = useStore();
 
   useEffect(() => {
@@ -71,13 +70,18 @@ export const ViewIssueModal = () => {
     { view: "ViewIssueModal", unregister: true },
     (register) => {
       register({
-        key: "o",
-        name: "Open in browser",
+        key: "m",
+        name: "Move issue",
         handler: () => {
-          const issue = store.get(issueAtom);
-          if (issue) {
-            openIssueInBrowser(issue.key);
-          }
+          openModal("moveIssue", store.get(issueAtom)!.id);
+        },
+      });
+
+      register({
+        key: "a",
+        name: "Update assignee",
+        handler: () => {
+          openModal("updateAssignee", store.get(issueAtom)!.id);
         },
       });
 
@@ -85,7 +89,7 @@ export const ViewIssueModal = () => {
         key: "p",
         name: "Update priority",
         handler: () => {
-          openModal("updatePriority");
+          openModal("updatePriority", store.get(issueAtom)!.id);
         },
       });
 
@@ -156,6 +160,17 @@ export const ViewIssueModal = () => {
       });
 
       register({
+        key: "o",
+        name: "Open in browser",
+        handler: () => {
+          const issue = store.get(issueAtom);
+          if (issue) {
+            openIssueInBrowser(issue.key);
+          }
+        },
+      });
+
+      register({
         ...CLOSE_KEY,
         name: "Close",
         handler: () => {
@@ -180,98 +195,82 @@ export const ViewIssueModal = () => {
   const width = 122 + 2 + 20 + 2;
 
   return (
-    <>
-      <Box
-        flexDirection="column"
-        position="absolute"
-        borderStyle={"round"}
-        borderColor={"greenBright"}
-        marginLeft={(columns - width) / 2}
-        marginTop={(rows - 50) / 2}
-      >
-        <Box flexDirection="row">
-          <Box flexDirection="column">
-            <Box
-              borderStyle={"round"}
-              borderColor={"green"}
-              width={122}
-              height={3}
-            >
-              <Text>{issue.fields.summary.padEnd(120, " ")}</Text>
-            </Box>
-            <Box
-              borderStyle={"round"}
-              borderColor={"green"}
-              width={122}
-              height={VIEWPORT_HEIGHT}
-              overflowY="hidden"
-            >
-              <Box flexDirection="column" marginTop={-topOffset}>
-                <Text>{paddedText}</Text>
-              </Box>
-            </Box>
+    <Box
+      flexDirection="column"
+      position="absolute"
+      borderStyle={"round"}
+      borderColor={"greenBright"}
+      marginLeft={(columns - width) / 2}
+      marginTop={(rows - 50) / 2}
+    >
+      <Box flexDirection="row">
+        <Box flexDirection="column">
+          <Box
+            borderStyle={"round"}
+            borderColor={"green"}
+            width={122}
+            height={3}
+          >
+            <Text>{issue.fields.summary.padEnd(120, " ")}</Text>
           </Box>
           <Box
             borderStyle={"round"}
             borderColor={"green"}
-            width={22}
-            height={38}
-            flexDirection="column"
+            width={122}
+            height={VIEWPORT_HEIGHT}
+            overflowY="hidden"
           >
-            <PaddedText text={`\uf292  ${issue.key}`} />
-            <PaddedText
-              text={`\uf43a  ${issue.fields.storyPoints !== null ? issue.fields.storyPoints : "N/A"}`}
-            />
-            <PaddedText
-              text={`\uf161  ${issue.fields.priority.name}`}
-              textProps={{
-                color: priorityMap[issue.fields.priority.name] ?? "yellow",
-              }}
-            />
-            <PaddedText text={`\uf007  ${issue.fields.assignee.displayName}`} />
-            {env.DEVELOPER_FIELD && (
-              <PaddedText text={`\uf121  ${issue.fields.developer}`} />
-            )}
-            <PaddedText text={`\uf50a  ${issue.fields.reporter.displayName}`} />
-            {Array.from({
-              length: 40 + (env.DEVELOPER_FIELD ? 0 : 1) - 10,
-            }).map((_, i) => (
-              // biome-ignore lint/suspicious/noArrayIndexKey: We're not actually showing any content, just spaces to override the underlying content
-              <PaddedText key={i} text={""} />
-            ))}
+            <Box flexDirection="column" marginTop={-topOffset}>
+              <Text>{paddedText}</Text>
+            </Box>
           </Box>
         </Box>
-        {description.length > VIEWPORT_HEIGHT && (
-          <Box
-            position="absolute"
-            borderStyle={"bold"}
-            borderColor={"greenBright"}
-            width={1}
-            marginLeft={width - 26}
-            borderTop={false}
-            borderRight={false}
-            borderBottom={false}
-            marginTop={
-              4 + (topOffset * 16) / (description.length - MINIMUM_LINES)
-            }
-            height={17}
+        <Box
+          borderStyle={"round"}
+          borderColor={"green"}
+          width={22}
+          height={38}
+          flexDirection="column"
+        >
+          <PaddedText text={`\uf292  ${issue.key}`} />
+          <PaddedText
+            text={`\uf43a  ${issue.fields.storyPoints !== null ? issue.fields.storyPoints : "N/A"}`}
           />
-        )}
+          <PaddedText
+            text={`\uf161  ${issue.fields.priority.name}`}
+            textProps={{
+              color: priorityMap[issue.fields.priority.name] ?? "yellow",
+            }}
+          />
+          <PaddedText text={`\uf007  ${issue.fields.assignee.displayName}`} />
+          {env.DEVELOPER_FIELD && (
+            <PaddedText text={`\uf121  ${issue.fields.developer}`} />
+          )}
+          <PaddedText text={`\uf50a  ${issue.fields.reporter.displayName}`} />
+          {Array.from({
+            length: 40 + (env.DEVELOPER_FIELD ? 0 : 1) - 10,
+          }).map((_, i) => (
+            // biome-ignore lint/suspicious/noArrayIndexKey: We're not actually showing any content, just spaces to override the underlying content
+            <PaddedText key={i} text={""} />
+          ))}
+        </Box>
       </Box>
-
-      {modals.updatePriority && (
-        <SelectPriorityModal
-          onClose={() => closeModal("updatePriority")}
-          onSelect={(priority) =>
-            updateIssue({
-              issueId: issue.id,
-              fields: {
-                priority: { id: priority.value, name: priority.label },
-              },
-            })
+      {description.length > VIEWPORT_HEIGHT && (
+        <Box
+          position="absolute"
+          borderStyle={"bold"}
+          borderColor={"greenBright"}
+          width={1}
+          marginLeft={width - 26}
+          borderTop={false}
+          borderRight={false}
+          borderBottom={false}
+          marginTop={
+            4 + (topOffset * 16) / (description.length - MINIMUM_LINES)
           }
+          height={17}
         />
       )}
-    </>
+    </Box>
   );
 };

--- a/src/modals/view-issue-modal.tsx
+++ b/src/modals/view-issue-modal.tsx
@@ -64,6 +64,10 @@ export const ViewIssueModal = ({
   useEffect(() => {
     store.set(issueAtom, issue);
     store.set(topOffsetAtom, 0); // Reset scroll offset when issue changes
+
+    return () => {
+      store.set(issueAtom, null);
+    };
   }, [store, issue]);
 
   useKeybinds(

--- a/src/modals/view-issue-modal.tsx
+++ b/src/modals/view-issue-modal.tsx
@@ -23,24 +23,6 @@ import { useStdoutDimensions } from "../useStdoutDimensions.js";
 const issueAtom = atom<Issue | null>(null);
 const topOffsetAtom = atom(0);
 
-const issueDescriptionAtom = atom((get) => {
-  const issue = get(issueAtom);
-  if (!issue) {
-    return [];
-  }
-
-  return new ADFRenderer(MAX_LINE_WIDTH, MINIMUM_LINES).render(
-    issue.fields.description?.content?.length
-      ? (issue.fields.description.content as TopLevelNode[])
-      : [
-          {
-            type: "paragraph",
-            content: [{ type: "text", text: "No description." }],
-          },
-        ],
-  );
-});
-
 const MINIMUM_LINES = 33;
 const VIEWPORT_HEIGHT = 35;
 const MAX_LINE_WIDTH = 119;
@@ -58,8 +40,20 @@ export const ViewIssueModal = ({
 
   const [columns, rows] = useStdoutDimensions();
   const topOffset = useAtomValue(topOffsetAtom);
-  const description = useAtomValue(issueDescriptionAtom);
   const store = useStore();
+
+  const description = issue
+    ? new ADFRenderer(MAX_LINE_WIDTH, MINIMUM_LINES).render(
+        issue.fields.description?.content?.length
+          ? (issue.fields.description.content as TopLevelNode[])
+          : [
+              {
+                type: "paragraph",
+                content: [{ type: "text", text: "No description." }],
+              },
+            ],
+      )
+    : [];
 
   useEffect(() => {
     store.set(issueAtom, issue);
@@ -105,9 +99,8 @@ export const ViewIssueModal = ({
         ],
         name: "Scroll down",
         hidden: true,
-        when: () => store.get(issueDescriptionAtom).length > VIEWPORT_HEIGHT,
+        when: () => description.length > VIEWPORT_HEIGHT,
         handler: () => {
-          const description = store.get(issueDescriptionAtom);
           store.set(topOffsetAtom, (prev) =>
             Math.min(
               prev + SMALL_SCROLL_INCREMENT,
@@ -125,7 +118,7 @@ export const ViewIssueModal = ({
         ],
         name: "Scroll up",
         hidden: true,
-        when: () => store.get(issueDescriptionAtom).length > VIEWPORT_HEIGHT,
+        when: () => description.length > VIEWPORT_HEIGHT,
         handler: () => {
           store.set(topOffsetAtom, (prev) =>
             Math.max(prev - SMALL_SCROLL_INCREMENT, 0),
@@ -138,10 +131,9 @@ export const ViewIssueModal = ({
         modifiers: ["ctrl"],
         name: "Scroll down (fast)",
         hidden: true,
-        when: () => store.get(issueDescriptionAtom).length > VIEWPORT_HEIGHT,
+        when: () => description.length > VIEWPORT_HEIGHT,
         handler: () => {
           store.set(topOffsetAtom, (prev) => {
-            const description = store.get(issueDescriptionAtom);
             return Math.min(
               prev + LARGE_SCROLL_INCREMENT,
               description.length - MINIMUM_LINES,
@@ -155,7 +147,7 @@ export const ViewIssueModal = ({
         modifiers: ["ctrl"],
         name: "Scroll up (fast)",
         hidden: true,
-        when: () => store.get(issueDescriptionAtom).length > VIEWPORT_HEIGHT,
+        when: () => description.length > VIEWPORT_HEIGHT,
         handler: () => {
           store.set(topOffsetAtom, (prev) =>
             Math.max(prev - LARGE_SCROLL_INCREMENT, 0),

--- a/src/modals/view-issue-modal.tsx
+++ b/src/modals/view-issue-modal.tsx
@@ -1,35 +1,37 @@
-import { Box, Text, useInput } from "ink";
+import { useQueryClient } from "@tanstack/react-query";
+import { Box, Text } from "ink";
+import { atom, useStore } from "jotai";
 import { useAtomValue } from "jotai";
-import { useState } from "react";
-import type { z } from "zod";
+import { useEffect } from "react";
 import { prefetchIssueTransitions } from "../api/get-issue-transitions.query.js";
-import type { issue as issueSchema } from "../api/get-issues.query.js";
+import type { Issue } from "../api/get-issues.query.js";
 import { prefetchPriorities } from "../api/get-priorities.query.js";
 import { prefetchUsers } from "../api/get-users.query.js";
-import { modalsAtom, openModal } from "../atoms/modals.atom.js";
+import { useUpdateIssueMutation } from "../api/update-issue.mutation.js";
+import { closeModal, modalsAtom, openModal } from "../atoms/modals.atom.js";
+import { viewedIssueAtom } from "../atoms/viewed-issue.atom.js";
 import { env } from "../env.js";
+import { useKeybinds } from "../hooks/use-keybinds.js";
+import { useViewedIssue } from "../hooks/use-viewed-issue.js";
 import { priorityMap } from "../issue.js";
 import { ADFRenderer } from "../lib/adf/adf-renderer.js";
 import type { TopLevelNode } from "../lib/adf/nodes.js";
+import { CLOSE_KEY, DOWN_KEY, UP_KEY } from "../lib/keybinds/keys.js";
 import { openIssueInBrowser } from "../lib/utils/openIssueInBrowser.js";
 import { PaddedText } from "../padded-text.js";
 import { useStdoutDimensions } from "../useStdoutDimensions.js";
+import { SelectPriorityModal } from "./select-priority-modal.js";
 
-export const ViewIssueModal = ({
-  issue,
-  onClose,
-}: {
-  issue: z.infer<typeof issueSchema>;
-  onClose: () => void;
-}) => {
-  prefetchUsers(issue.id);
-  prefetchPriorities(issue.fields.project.id);
-  prefetchIssueTransitions(issue.id);
-  const [columns, rows] = useStdoutDimensions();
-  const [topOffset, setTopOffset] = useState(0);
-  const modals = useAtomValue(modalsAtom);
+const issueAtom = atom<Issue | null>(null);
+const topOffsetAtom = atom(0);
 
-  const description = new ADFRenderer(119, 33).render(
+const issueDescriptionAtom = atom((get) => {
+  const issue = get(issueAtom);
+  if (!issue) {
+    return [];
+  }
+
+  return new ADFRenderer(MAX_LINE_WIDTH, MINIMUM_LINES).render(
     issue.fields.description?.content?.length
       ? (issue.fields.description.content as TopLevelNode[])
       : [
@@ -39,120 +41,237 @@ export const ViewIssueModal = ({
           },
         ],
   );
+});
 
-  const lines = description.length;
+const MINIMUM_LINES = 33;
+const VIEWPORT_HEIGHT = 35;
+const MAX_LINE_WIDTH = 119;
+
+const SMALL_SCROLL_INCREMENT = 3;
+const LARGE_SCROLL_INCREMENT = 10;
+
+export const ViewIssueModal = () => {
+  const issue = useViewedIssue();
+  const queryClient = useQueryClient();
+
+  const { mutate: updateIssue } = useUpdateIssueMutation();
+
+  const [columns, rows] = useStdoutDimensions();
+  const topOffset = useAtomValue(topOffsetAtom);
+  const description = useAtomValue(issueDescriptionAtom);
+  const modals = useAtomValue(modalsAtom);
+  const store = useStore();
+
+  useEffect(() => {
+    store.set(issueAtom, issue);
+    store.set(topOffsetAtom, 0); // Reset scroll offset when issue changes
+  }, [store, issue]);
+
+  useKeybinds(
+    { view: "ViewIssueModal", unregister: true },
+    (register) => {
+      register({
+        key: "o",
+        name: "Open in browser",
+        handler: () => {
+          const issue = store.get(issueAtom);
+          if (issue) {
+            openIssueInBrowser(issue.key);
+          }
+        },
+      });
+
+      register({
+        key: "p",
+        name: "Update priority",
+        handler: () => {
+          openModal("updatePriority");
+        },
+      });
+
+      register({
+        ...DOWN_KEY,
+        aliases: [
+          { key: "", modifiers: ["downArrow"] },
+          { key: "d", modifiers: ["ctrl"] },
+        ],
+        name: "Scroll down",
+        hidden: true,
+        when: () => store.get(issueDescriptionAtom).length > VIEWPORT_HEIGHT,
+        handler: () => {
+          const description = store.get(issueDescriptionAtom);
+          store.set(topOffsetAtom, (prev) =>
+            Math.min(
+              prev + SMALL_SCROLL_INCREMENT,
+              description.length - MINIMUM_LINES,
+            ),
+          );
+        },
+      });
+
+      register({
+        ...UP_KEY,
+        aliases: [
+          { key: "", modifiers: ["upArrow"] },
+          { key: "u", modifiers: ["ctrl"] },
+        ],
+        name: "Scroll up",
+        hidden: true,
+        when: () => store.get(issueDescriptionAtom).length > VIEWPORT_HEIGHT,
+        handler: () => {
+          store.set(topOffsetAtom, (prev) =>
+            Math.max(prev - SMALL_SCROLL_INCREMENT, 0),
+          );
+        },
+      });
+
+      register({
+        key: "d",
+        modifiers: ["ctrl"],
+        name: "Scroll down (fast)",
+        hidden: true,
+        when: () => store.get(issueDescriptionAtom).length > VIEWPORT_HEIGHT,
+        handler: () => {
+          store.set(topOffsetAtom, (prev) => {
+            const description = store.get(issueDescriptionAtom);
+            return Math.min(
+              prev + LARGE_SCROLL_INCREMENT,
+              description.length - MINIMUM_LINES,
+            );
+          });
+        },
+      });
+
+      register({
+        key: "u",
+        modifiers: ["ctrl"],
+        name: "Scroll up (fast)",
+        hidden: true,
+        when: () => store.get(issueDescriptionAtom).length > VIEWPORT_HEIGHT,
+        handler: () => {
+          store.set(topOffsetAtom, (prev) =>
+            Math.max(prev - LARGE_SCROLL_INCREMENT, 0),
+          );
+        },
+      });
+
+      register({
+        ...CLOSE_KEY,
+        name: "Close",
+        handler: () => {
+          store.set(viewedIssueAtom, null);
+        },
+      });
+    },
+    [],
+  );
+
+  if (!issue) {
+    return null;
+  }
+
+  prefetchUsers(queryClient, issue.id);
+  prefetchPriorities(queryClient, issue.fields.project.id);
+  prefetchIssueTransitions(queryClient, issue.id);
+
   const paddedText = description.map((line) => `${line} `).join("\n");
-
-  useInput((input, key) => {
-    if (!modals.updateAssignee && !modals.updatePriority) {
-      if (input === "o") {
-        openIssueInBrowser(issue.key);
-        return;
-      }
-
-      if (input === "p") {
-        openModal("updatePriority");
-        return;
-      }
-
-      if (lines > 35) {
-        if (input === "j" || key.downArrow) {
-          setTopOffset((prev) => Math.min(prev + 3, lines - 33));
-        }
-        if (input === "k" || key.upArrow) {
-          setTopOffset((prev) => Math.max(prev - 3, 0));
-        }
-      }
-
-      if (input === "q" || key.escape) {
-        onClose();
-      }
-    }
-  });
 
   // title/description + outer borders + assignees + assignee borders
   const width = 122 + 2 + 20 + 2;
 
   return (
-    <Box
-      flexDirection="column"
-      position="absolute"
-      borderStyle={"round"}
-      borderColor={"greenBright"}
-      height={41}
-      marginLeft={(columns - width) / 2}
-      marginTop={(rows - 50) / 2}
-    >
-      <Box flexDirection="row">
-        <Box flexDirection="column">
-          <Box
-            borderStyle={"round"}
-            borderColor={"green"}
-            width={122}
-            height={3}
-          >
-            <Text>{issue.fields.summary.padEnd(120, " ")}</Text>
-          </Box>
-          <Box
-            borderStyle={"round"}
-            borderColor={"green"}
-            width={122}
-            height={35}
-            overflowY="hidden"
-          >
-            <Box flexDirection="column" marginTop={-topOffset}>
-              <Text>{paddedText}</Text>
+    <>
+      <Box
+        flexDirection="column"
+        position="absolute"
+        borderStyle={"round"}
+        borderColor={"greenBright"}
+        marginLeft={(columns - width) / 2}
+        marginTop={(rows - 50) / 2}
+      >
+        <Box flexDirection="row">
+          <Box flexDirection="column">
+            <Box
+              borderStyle={"round"}
+              borderColor={"green"}
+              width={122}
+              height={3}
+            >
+              <Text>{issue.fields.summary.padEnd(120, " ")}</Text>
+            </Box>
+            <Box
+              borderStyle={"round"}
+              borderColor={"green"}
+              width={122}
+              height={VIEWPORT_HEIGHT}
+              overflowY="hidden"
+            >
+              <Box flexDirection="column" marginTop={-topOffset}>
+                <Text>{paddedText}</Text>
+              </Box>
             </Box>
           </Box>
-        </Box>
-        <Box
-          borderStyle={"round"}
-          borderColor={"green"}
-          width={22}
-          height={38}
-          flexDirection="column"
-        >
-          <PaddedText text={`\uf292  ${issue.key}`} />
-          <PaddedText
-            text={`\uf43a  ${issue.fields.storyPoints !== null ? issue.fields.storyPoints : "N/A"}`}
-          />
-          <PaddedText
-            text={`\uf161  ${issue.fields.priority.name}`}
-            textProps={{
-              color: priorityMap[issue.fields.priority.name] ?? "yellow",
-            }}
-          />
-          <PaddedText text={`\uf007  ${issue.fields.assignee.displayName}`} />
-          {env.DEVELOPER_FIELD && (
-            <PaddedText text={`\uf121  ${issue.fields.developer}`} />
-          )}
-          <PaddedText text={`\uf50a  ${issue.fields.reporter.displayName}`} />
-          {Array.from({ length: 40 + (env.DEVELOPER_FIELD ? 0 : 1) - 10 }).map(
-            (_, i) => (
+          <Box
+            borderStyle={"round"}
+            borderColor={"green"}
+            width={22}
+            height={38}
+            flexDirection="column"
+          >
+            <PaddedText text={`\uf292  ${issue.key}`} />
+            <PaddedText
+              text={`\uf43a  ${issue.fields.storyPoints !== null ? issue.fields.storyPoints : "N/A"}`}
+            />
+            <PaddedText
+              text={`\uf161  ${issue.fields.priority.name}`}
+              textProps={{
+                color: priorityMap[issue.fields.priority.name] ?? "yellow",
+              }}
+            />
+            <PaddedText text={`\uf007  ${issue.fields.assignee.displayName}`} />
+            {env.DEVELOPER_FIELD && (
+              <PaddedText text={`\uf121  ${issue.fields.developer}`} />
+            )}
+            <PaddedText text={`\uf50a  ${issue.fields.reporter.displayName}`} />
+            {Array.from({
+              length: 40 + (env.DEVELOPER_FIELD ? 0 : 1) - 10,
+            }).map((_, i) => (
               // biome-ignore lint/suspicious/noArrayIndexKey: We're not actually showing any content, just spaces to override the underlying content
               <PaddedText key={i} text={""} />
-            ),
-          )}
+            ))}
+          </Box>
         </Box>
+        {description.length > VIEWPORT_HEIGHT && (
+          <Box
+            position="absolute"
+            borderStyle={"bold"}
+            borderColor={"greenBright"}
+            width={1}
+            marginLeft={width - 26}
+            borderTop={false}
+            borderRight={false}
+            borderBottom={false}
+            marginTop={
+              4 + (topOffset * 16) / (description.length - MINIMUM_LINES)
+            }
+            height={17}
+          />
+        )}
       </Box>
-      <PaddedText
-        text=" Open issue in browser: o | Update assignee: a | Update priority: p | Move issue: m | Close: q"
-        maxLength={144}
-      />
-      {lines > 35 && (
-        <Box
-          position="absolute"
-          borderStyle={"bold"}
-          borderColor={"greenBright"}
-          width={1}
-          marginLeft={width - 26}
-          borderTop={false}
-          borderRight={false}
-          borderBottom={false}
-          marginTop={4 + (topOffset * 16) / (lines - 33)}
-          height={17}
+
+      {modals.updatePriority && (
+        <SelectPriorityModal
+          onClose={() => closeModal("updatePriority")}
+          onSelect={(priority) =>
+            updateIssue({
+              issueId: issue.id,
+              fields: {
+                priority: { id: priority.value, name: priority.label },
+              },
+            })
+          }
         />
       )}
-    </Box>
+    </>
   );
 };


### PR DESCRIPTION
Part of #30

* Added a `useKeybinds` hook which provides a `register` callback where you an register keybinds for that component (with the option to unregister on unmount, for modals)
* Keybinds for the active view are displayed globally (inspired by Lazygit)